### PR TITLE
feat: Agrupar secciones de presupuesto en macro-secciones lógicas

### DIFF
--- a/projects/views.py
+++ b/projects/views.py
@@ -1756,9 +1756,128 @@ def detailed_budget_view(request, project_id):
     # ✅ USAR EL CÁLCULO CORRECTO QUE INCLUYE ADMINISTRACIÓN
     total_budget = project.calculate_final_budget()
     
+    # Agrupar secciones en macro-secciones lógicas
+    macro_sections = {
+        'Obra Negra': {
+            'name': 'Obra Negra',
+            'description': 'Cimientos, estructura, columnas, vigas',
+            'icon': 'fas fa-building',
+            'color': 'primary',
+            'sections': [],
+            'total': Decimal('0')
+        },
+        'Obra Blanca': {
+            'name': 'Obra Blanca',
+            'description': 'Mampostería, revoques, instalaciones básicas',
+            'icon': 'fas fa-paint-roller',
+            'color': 'info',
+            'sections': [],
+            'total': Decimal('0')
+        },
+        'Acabados': {
+            'name': 'Acabados',
+            'description': 'Pisos, pintura, carpintería, ventanas, puertas',
+            'icon': 'fas fa-hammer',
+            'color': 'success',
+            'sections': [],
+            'total': Decimal('0')
+        },
+        'Instalaciones': {
+            'name': 'Instalaciones',
+            'description': 'Hidráulicas, eléctricas, gas',
+            'icon': 'fas fa-plug',
+            'color': 'warning',
+            'sections': [],
+            'total': Decimal('0')
+        },
+        'Exteriores': {
+            'name': 'Exteriores',
+            'description': 'Fachada, zonas comunes, paisajismo',
+            'icon': 'fas fa-tree',
+            'color': 'secondary',
+            'sections': [],
+            'total': Decimal('0')
+        },
+        'Otros': {
+            'name': 'Otros',
+            'description': 'Preliminares, supervisión, administración, impuestos',
+            'icon': 'fas fa-list',
+            'color': 'dark',
+            'sections': [],
+            'total': Decimal('0')
+        }
+    }
+    
+    # Mapeo de secciones a macro-secciones según su order
+    section_to_macro = {
+        # Obra Negra
+        2: 'Obra Negra',   # EXCAVACIONES Y LLENOS
+        3: 'Obra Negra',   # CIMENTACIONES
+        4: 'Obra Negra',   # ESTRUCTURA
+        5: 'Obra Negra',   # ACERO
+        
+        # Obra Blanca
+        6: 'Obra Blanca',  # MAMPOSTERÍA
+        7: 'Obra Blanca',  # ESTUCOS, REVOQUES, PINTURAS, DRYWALL
+        
+        # Acabados
+        8: 'Acabados',     # PISOS, ENCHAPES Y SÓCALOS
+        9: 'Acabados',     # JUNTAS
+        10: 'Acabados',    # CARPINTERÍA METÁLICA Y VIDRIOS
+        11: 'Acabados',    # CARPINTERÍA EN MADERA, MESONES Y ACCESORIOS
+        
+        # Instalaciones
+        12: 'Instalaciones',  # APARATOS SANITARIOS E INSTALACIONES HIDRÁULICAS
+        13: 'Instalaciones',  # INSTALACIONES ELÉCTRICAS Y REDES DE GAS
+        
+        # Exteriores
+        14: 'Exteriores',  # CUBIERTAS
+        17: 'Exteriores',  # PISOS EXTERIORES
+        19: 'Exteriores',  # PAISAJISMO
+        
+        # Otros (por defecto)
+        1: 'Otros',        # PRELIMINARES Y MANTENIMIENTOS
+        15: 'Otros',       # ELECTRODOMÉSTICOS
+        16: 'Otros',       # IMPERMEABILIZACIONES
+        18: 'Otros',       # LIMPIEZA GENERAL Y VIDRIOS
+        20: 'Otros',       # SUPERVISIÓN Y CONTROL DE OBRA
+        21: 'Otros',       # ADMINISTRACIÓN
+        22: 'Otros',       # IMPUESTOS Y ESCRITURACIONES
+        23: 'Otros',       # ESTUDIOS Y DISEÑO
+    }
+    
+    # Agrupar secciones
+    for section_item in section_data:
+        section_order = section_item['section'].order
+        macro_key = section_to_macro.get(section_order, 'Otros')
+        
+        # Calcular total de la sección
+        if section_item['section'].is_percentage and section_item['section'].order == 21:
+            section_total = administracion_automatica
+        else:
+            section_total = Decimal(str(section_item['total']))
+        
+        macro_sections[macro_key]['sections'].append(section_item)
+        macro_sections[macro_key]['total'] += section_total
+    
+    # Convertir totales a float para el template
+    for macro_key in macro_sections:
+        macro_sections[macro_key]['total'] = float(macro_sections[macro_key]['total'])
+    
+    # Ordenar macro-secciones según el orden deseado
+    macro_sections_ordered = [
+        macro_sections['Obra Negra'],
+        macro_sections['Obra Blanca'],
+        macro_sections['Acabados'],
+        macro_sections['Instalaciones'],
+        macro_sections['Exteriores'],
+        macro_sections['Otros']
+    ]
+    
     context = {
         'project': project,
         'section_data': section_data,
+        'macro_sections': macro_sections_ordered,
         'total_budget': total_budget,
         'administration_percentage': project.administration_percentage,
         'costo_directo': costo_directo_total,

--- a/templates/projects/detailed_budget_view.html
+++ b/templates/projects/detailed_budget_view.html
@@ -28,7 +28,56 @@
                     </div>
                     <div class="card-body p-4 bg-gray-green-accent">
                         
-                        <!-- Navegación por Secciones -->
+                        <!-- Macro-secciones Agrupadas -->
+                        <div class="mb-5">
+                            <h5 class="fw-bold mb-4">
+                                <i class="fas fa-layer-group me-2"></i>
+                                Presupuesto por Macro-secciones
+                            </h5>
+                            <div class="row g-3">
+                                {% for macro in macro_sections %}
+                                    {% if macro.sections %}
+                                        <div class="col-md-6 col-lg-4">
+                                            <div class="card h-100 border-{{ macro.color }} shadow-sm">
+                                                <div class="card-header bg-{{ macro.color }} text-white">
+                                                    <div class="d-flex align-items-center justify-content-between">
+                                                        <div>
+                                                            <i class="{{ macro.icon }} me-2"></i>
+                                                            <strong>{{ macro.name }}</strong>
+                                                        </div>
+                                                        <span class="badge bg-light text-{{ macro.color }} price-display" data-price="{{ macro.total }}">
+                                                            ${{ macro.total|floatformat:0|default:"0" }}
+                                                        </span>
+                                                    </div>
+                                                    <small class="text-white-50">{{ macro.description }}</small>
+                                                </div>
+                                                <div class="card-body">
+                                                    <div class="list-group list-group-flush">
+                                                        {% for section in macro.sections %}
+                                                            <a href="#section-{{ section.section.id }}" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
+                                                                <span>
+                                                                    <strong>{{ section.section.order }}.</strong>
+                                                                    {% if section.section.is_percentage and section.section.order == 21 %}
+                                                                        ADMINISTRACIÓN
+                                                                    {% else %}
+                                                                        {{ section.section.name|truncatechars:30 }}
+                                                                    {% endif %}
+                                                                </span>
+                                                                <span class="badge bg-{{ macro.color }} rounded-pill price-display" data-price="{% if section.section.is_percentage and section.section.order == 21 %}{{ administracion_automatica }}{% else %}{{ section.total }}{% endif %}">
+                                                                    ${% if section.section.is_percentage and section.section.order == 21 %}{{ administracion_automatica|floatformat:0|default:"0" }}{% else %}{{ section.total|floatformat:0|default:"0" }}{% endif %}
+                                                                </span>
+                                                            </a>
+                                                        {% endfor %}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        </div>
+                        
+                        <!-- Navegación Rápida por Secciones (mantener para compatibilidad) -->
                         <div class="mb-4">
                             <h5 class="fw-bold mb-3">
                                 <i class="fas fa-list-ol me-2"></i>


### PR DESCRIPTION
- Agregar agrupamiento de secciones en 6 macro-secciones:
  * Obra Negra (cimientos, estructura, columnas, vigas)
  * Obra Blanca (mampostería, revoques, instalaciones básicas)
  * Acabados (pisos, pintura, carpintería, ventanas, puertas)
  * Instalaciones (hidráulicas, eléctricas, gas)
  * Exteriores (fachada, zonas comunes, paisajismo)
  * Otros (preliminares, supervisión, administración, impuestos)
- Mostrar macro-secciones en tarjetas con iconos y colores distintivos
- Calcular totales por macro-sección automáticamente
- Agregar navegación rápida desde macro-secciones a secciones individuales
- Mejorar UX para usuarios que completan presupuestos frecuentemente